### PR TITLE
Update lidl.js to add extra manufacturer for TY0203

### DIFF
--- a/src/devices/lidl.js
+++ b/src/devices/lidl.js
@@ -288,7 +288,10 @@ module.exports = [
         },
     },
     {
-        fingerprint: [{modelID: 'TY0203', manufacturerName: '_TZ1800_ejwkn2h2'}],
+        fingerprint: [
+            {modelID: 'TY0203', manufacturerName: '_TZ1800_ejwkn2h2'},
+            {modelID: 'TY0203', manufacturerName: '_TZ1800_ho6i0zk9'}
+        ],
         model: 'HG06336',
         vendor: 'Lidl',
         description: 'Silvercrest smart window and door sensor',


### PR DESCRIPTION
I have a TY0203 Silvercrest smart window and door sensor, but the manufacturer name is different to the existing one provided.